### PR TITLE
feat: add drag-and-drop, premoving, and input polish.

### DIFF
--- a/frontend/board/board_node.gd
+++ b/frontend/board/board_node.gd
@@ -9,7 +9,10 @@ enum BoardNodeState {
 enum InputState {
 	NONE,
 	CHOOSING_PROMOTION,
+	DRAGGING,
 }
+
+const DRAG_THRESHOLD := 4.0
 
 @export var ai_vs_ai_mode: bool
 
@@ -24,6 +27,15 @@ var state: BoardNodeState = BoardNodeState.NOT_INITIALIZED
 var input_state: InputState = InputState.NONE
 var selected_piece_node: PieceNode = null
 var temp_move_action: MoveAction = null
+var premove_action: MoveAction = null
+var _pointer_down: bool = false
+var _pointer_start_pos: Vector2 = Vector2.ZERO
+var _active_pointer_id: int = -1
+var _is_dragging: bool = false
+var _suppress_click_signals: bool = false
+var _drag_piece_node: PieceNode = null
+var _press_piece_node: PieceNode = null
+var _pending_premove_execute: bool = false
 
 func init_with_game_setup(game_setup: GameSetup) -> void:
 	assert(Config.loaded, "Config not loaded!")
@@ -67,30 +79,175 @@ func init_randomly() -> void:
 	if ai_vs_ai_mode:
 		_trigger_ai_move()
 
+func _input(event: InputEvent) -> void:
+	if ai_vs_ai_mode or state != BoardNodeState.INITIALIZED:
+		return
+	if input_state == InputState.CHOOSING_PROMOTION:
+		return
+	
+	if event is InputEventScreenTouch:
+		var touch := event as InputEventScreenTouch
+		if touch.canceled and touch.index == _active_pointer_id:
+			_handle_pointer_cancelled()
+		else:
+			_handle_pointer(touch.index, touch.position, touch.pressed)
+	elif event is InputEventScreenDrag:
+		if _pointer_down and event.index == _active_pointer_id:
+			_handle_pointer_motion(event.position)
+	elif event is InputEventMouseButton and event.button_index == MOUSE_BUTTON_LEFT:
+		_handle_pointer(-1, event.position, event.pressed)
+	elif event is InputEventMouseMotion and _pointer_down and _active_pointer_id == -1:
+		_handle_pointer_motion(event.position)
+
+func _handle_pointer(pointer_id: int, screen_pos: Vector2, pressed: bool) -> void:
+	if pressed:
+		if _pointer_down:
+			return
+		_pointer_down = true
+		_active_pointer_id = pointer_id
+		_pointer_start_pos = screen_pos
+		_is_dragging = false
+		
+		var world_pos := _screen_to_world(screen_pos)
+		_press_piece_node = _get_player_piece_at_world_pos(world_pos)
+		if _press_piece_node and not _press_piece_node.is_moving() and selected_piece_node == null:
+			if b.team_to_move == player_team or Settings.premoving_enabled:
+				_select_piece_node(_press_piece_node)
+	else:
+		if not _pointer_down or pointer_id != _active_pointer_id:
+			return
+		
+		if _is_dragging:
+			var world_pos := _screen_to_world(screen_pos)
+			_finish_drag(world_pos)
+			get_viewport().set_input_as_handled()
+		
+		_pointer_down = false
+		_active_pointer_id = -1
+		_is_dragging = false
+		_suppress_click_signals = false
+		_press_piece_node = null
+		
+		if _pending_premove_execute:
+			_pending_premove_execute = false
+			_try_execute_premove()
+
+func _handle_pointer_cancelled() -> void:
+	_cancel_drag()
+	_pointer_down = false
+	_active_pointer_id = -1
+	_is_dragging = false
+	_suppress_click_signals = false
+	_press_piece_node = null
+	if _pending_premove_execute:
+		_pending_premove_execute = false
+		_try_execute_premove()
+
+func _handle_pointer_motion(screen_pos: Vector2) -> void:
+	if not _pointer_down:
+		return
+	
+	var drag_piece := selected_piece_node
+	if _press_piece_node and is_instance_valid(_press_piece_node) and not _press_piece_node.is_moving():
+		drag_piece = _press_piece_node
+	if not drag_piece or drag_piece.is_moving():
+		return
+	
+	if not _is_dragging:
+		if screen_pos.distance_to(_pointer_start_pos) < DRAG_THRESHOLD:
+			return
+		if drag_piece != selected_piece_node:
+			_select_piece_node(drag_piece)
+		if not selected_piece_node:
+			return
+		_start_drag()
+	
+	var world_pos := _screen_to_world(screen_pos)
+	var local_pos := piece_nodes.to_local(world_pos)
+	selected_piece_node.update_drag_position(local_pos)
+	var board_pos := tile_nodes.world_pos_to_board_pos(world_pos)
+	if tile_nodes.has_tile_node(board_pos):
+		tile_nodes.set_drag_hover_tile(board_pos)
+	else:
+		tile_nodes.clear_drag_hover()
+	get_viewport().set_input_as_handled()
+
+func _start_drag() -> void:
+	_is_dragging = true
+	_suppress_click_signals = true
+	input_state = InputState.DRAGGING
+	_drag_piece_node = selected_piece_node
+	selected_piece_node.begin_drag()
+
+func _finish_drag(world_pos: Vector2) -> void:
+	var dragged_piece := _drag_piece_node if _drag_piece_node else selected_piece_node
+	if not dragged_piece:
+		_abort_drag(true)
+		return
+	
+	var target_pos := tile_nodes.world_pos_to_board_pos(world_pos)
+	var target_piece_node: PieceNode = null
+	if b.piece_map.has_piece(target_pos):
+		target_piece_node = piece_nodes.get_piece_node_by_pos(target_pos)
+	
+	input_state = InputState.NONE
+	tile_nodes.clear_drag_hover()
+	_is_dragging = false
+	_drag_piece_node = null
+	
+	if b.team_to_move != player_team and Settings.premoving_enabled and _can_premove_to(dragged_piece, target_pos):
+		dragged_piece.end_drag(true)
+		_set_premove(dragged_piece, target_pos)
+	elif b.team_to_move == player_team:
+		selected_piece_node = dragged_piece
+		dragged_piece.end_drag(true)
+		if not _attempt_move_to(target_pos, target_piece_node) and tile_nodes.has_tile_node(dragged_piece.piece().pos):
+			tile_nodes.get_tile_node(dragged_piece.piece().pos).animate_flash(0.9, 0.2)
+	else:
+		dragged_piece.end_drag(true)
+		if tile_nodes.has_tile_node(dragged_piece.piece().pos):
+			tile_nodes.get_tile_node(dragged_piece.piece().pos).animate_flash(0.9, 0.2)
+
+func _cancel_drag() -> void:
+	_abort_drag(true)
+
+func _abort_drag(restore_position: bool = true) -> void:
+	if _drag_piece_node and is_instance_valid(_drag_piece_node) and _drag_piece_node.is_dragging():
+		_drag_piece_node.end_drag(restore_position)
+	_drag_piece_node = null
+	_is_dragging = false
+	if input_state == InputState.DRAGGING:
+		input_state = InputState.NONE
+	tile_nodes.clear_drag_hover()
+
+func _screen_to_world(screen_pos: Vector2) -> Vector2:
+	return get_viewport().get_canvas_transform().affine_inverse() * screen_pos
+
+func _get_player_piece_at_world_pos(world_pos: Vector2) -> PieceNode:
+	var board_pos := tile_nodes.world_pos_to_board_pos(world_pos)
+	if not b.piece_map.has_piece(board_pos):
+		return null
+	var piece := b.piece_map.get_piece(board_pos)
+	if piece.team != player_team:
+		return null
+	return piece_nodes.get_piece_node_by_pos(board_pos)
+
 func _on_piece_node_selected(piece_node: PieceNode) -> void:
+	if _suppress_click_signals:
+		return
+	
 	var tile_node: TileNode = tile_nodes.get_tile_node(piece_node.piece().pos)
 	tile_node.animate_flash(1.1)
-	if ai_vs_ai_mode: return
+	if ai_vs_ai_mode:
+		return
 		
 	if b.team_to_move == player_team and selected_piece_node:
-		assert(selected_piece_node.piece().team == player_team)
-		# Castling where the rook sits on the king's destination square
-		var castle_move := _get_castle_move_to(piece_node.piece().pos)
-		if castle_move != null:
-			var castle_action := MoveAction.new(selected_piece_node.id(), castle_move.to, castle_move.info)
-			perform_move_action(castle_action)
-			end_player_turn()
+		if _attempt_move_to(piece_node.piece().pos, piece_node):
 			return
-		if _can_capture(piece_node):
-			var move_action: MoveAction
-			if b.tile_map.is_promotion_tile(piece_node.piece().pos, player_team) and selected_piece_node.piece().type == Piece.Type.PAWN:
-				temp_move_action = MoveAction.new(selected_piece_node.id(), piece_node.piece().pos, Move.CAPTURE, Piece.Type.UNSET, piece_node.id())
-				input_state = InputState.CHOOSING_PROMOTION
-				promotion_ui.show()
-			else:
-				move_action = MoveAction.new(selected_piece_node.id(), piece_node.piece().pos, Move.CAPTURE, Piece.Type.UNSET, piece_node.id())
-				perform_move_action(move_action)
-				end_player_turn()
+	
+	if b.team_to_move != player_team and Settings.premoving_enabled and selected_piece_node:
+		if piece_node != selected_piece_node and _can_premove_to(selected_piece_node, piece_node.piece().pos):
+			_set_premove(selected_piece_node, piece_node.piece().pos)
 			return
 	
 	if _can_select(piece_node):
@@ -100,39 +257,28 @@ func _on_piece_node_selected(piece_node: PieceNode) -> void:
 		_select_piece_node(null)
 
 func _on_tile_node_selected(tile_node: TileNode) -> void:
+	if _suppress_click_signals:
+		return
+	
 	tile_node.animate_flash(1.1)
-	if ai_vs_ai_mode: return
+	if ai_vs_ai_mode:
+		return
 		
 	if b.team_to_move == player_team and selected_piece_node:
-		assert(selected_piece_node.piece().team == player_team)
-		if _can_move_to(tile_node):
-			var move_action: MoveAction
-			var target_move := _get_available_move_to(tile_node.pos())
-			if b.tile_map.is_promotion_tile(tile_node.pos(), player_team) and selected_piece_node.piece().type == Piece.Type.PAWN:
-				temp_move_action = MoveAction.new(selected_piece_node.id(), tile_node.pos(), 0, Piece.Type.UNSET)
-				input_state = InputState.CHOOSING_PROMOTION
-				promotion_ui.show()
-			elif target_move != null and target_move.is_en_passant():
-				# The captured pawn sits beside the (empty) landing square.
-				var captured_pos := Vector2i(tile_node.pos().x, selected_piece_node.piece().pos.y)
-				var captured_piece_id := piece_nodes.get_piece_node_by_pos(captured_pos).id()
-				move_action = MoveAction.new(selected_piece_node.id(), tile_node.pos(), target_move.info, Piece.Type.UNSET, captured_piece_id)
-				perform_move_action(move_action)
-				end_player_turn()
-			else:
-				# Preserve move flags (e.g. castling) from the matching legal move
-				var chosen_move := _get_available_move_to(tile_node.pos())
-				var move_info: int = chosen_move.info if chosen_move else 0
-				move_action = MoveAction.new(selected_piece_node.id(), tile_node.pos(), move_info)
-				perform_move_action(move_action)
-				end_player_turn()
+		if _attempt_move_to(tile_node.pos()):
+			return
+	
+	if b.team_to_move != player_team and Settings.premoving_enabled and selected_piece_node:
+		if _can_premove_to(selected_piece_node, tile_node.pos()):
+			_set_premove(selected_piece_node, tile_node.pos())
 			return
 	
 	promotion_ui.hide()
 	_select_piece_node(null)
 
 func _on_promotion_ui_promotion_chosen(promotion_type: Piece.Type) -> void:
-	if ai_vs_ai_mode: return
+	if ai_vs_ai_mode:
+		return
 		
 	assert(temp_move_action)
 	assert(input_state == InputState.CHOOSING_PROMOTION)
@@ -150,15 +296,26 @@ func _select_piece_node(piece_node: PieceNode) -> void:
 		selected_piece_node.set_selected(false)
 	selected_piece_node = piece_node
 	if piece_node:
+		if b.team_to_move != player_team and not Settings.premoving_enabled:
+			selected_piece_node = null
+			tile_nodes.highlight_tiles([])
+			return
+		var tiles_to_highlight: Array[Vector2i] = []
 		if b.team_to_move == player_team:
 			var available_moves := b.get_available_moves_from(piece_node.piece().pos)
-			var tiles_to_highlight: Array[Vector2i] = []
 			for move: Move in available_moves:
 				tiles_to_highlight.append(move.to)
-			tile_nodes.highlight_tiles(tiles_to_highlight)
+		else:
+			tiles_to_highlight = _get_premove_targets(piece_node.piece().pos)
+		tile_nodes.highlight_tiles(tiles_to_highlight)
 		piece_node.set_selected(true)
 	else:
 		tile_nodes.highlight_tiles([])
+
+func clear_premoves() -> void:
+	_clear_premove()
+	if b and b.team_to_move != player_team:
+		_select_piece_node(null)
 
 func end_player_turn() -> void:
 	if b.is_match_over():
@@ -177,6 +334,13 @@ func end_ai_turn() -> void:
 			ai_thread1.process_board(b)
 		else:
 			ai_thread2.process_board(b)
+		return
+	
+	if b.team_to_move == player_team:
+		if _pointer_down or _is_dragging:
+			_pending_premove_execute = true
+		else:
+			_try_execute_premove()
 
 func _on_game_over(game_result: Match.Result) -> void:
 	game_over.emit(game_result)
@@ -198,17 +362,20 @@ func _on_game_over(game_result: Match.Result) -> void:
 
 
 func _on_ai_thread_move_found(move: Move) -> void:
-	# Create move action
 	var from := move.from
 	var to := move.to
-	var piece_id := piece_nodes.get_piece_node_by_pos(from).id()
+	var from_node := piece_nodes.get_piece_node_by_pos(from)
+	if from_node == null:
+		return
+	var piece_id := from_node.id()
 	var captured_piece_id := 0
 	if move.is_capture():
 		var captured_pos := to
 		if move.is_en_passant():
-			# The captured pawn is beside the landing square.
 			captured_pos = Vector2i(to.x, from.y)
-		captured_piece_id = piece_nodes.get_piece_node_by_pos(captured_pos).id()
+		var captured_node := piece_nodes.get_piece_node_by_pos(captured_pos)
+		if captured_node:
+			captured_piece_id = captured_node.id()
 	var move_action: MoveAction = MoveAction.new(piece_id, to, move.info, move.promo_info, captured_piece_id)
 	perform_move_action(move_action)
 	end_ai_turn()
@@ -226,10 +393,10 @@ func _can_capture(piece_node: PieceNode) -> bool:
 		assert(move.to != piece_node.piece().pos, "you shouldn't be able to move here without a capture flag")
 	return false
 
-func _can_move_to(tile_node: TileNode) -> bool:
+func _can_move_to_pos(target_pos: Vector2i) -> bool:
 	var available_moves := b.get_available_moves_from(selected_piece_node.piece().pos)
 	for move: Move in available_moves:
-		if move.to == tile_node.pos():
+		if move.to == target_pos:
 			return true
 	return false
 
@@ -248,14 +415,199 @@ func _get_castle_move_to(pos: Vector2i) -> Move:
 			return move
 	return null
 
+func _get_premove_targets(from: Vector2i) -> Array[Vector2i]:
+	var targets: Array[Vector2i] = []
+	if not b.piece_map.has_piece(from):
+		return targets
+	var piece := b.piece_map.get_piece(from)
+	if piece.team != player_team:
+		return targets
+	var seen: Dictionary = {}
+	for move: Move in piece.get_available_moves(b):
+		if not seen.has(move.to):
+			targets.append(move.to)
+			seen[move.to] = true
+	for tile_node: TileNode in tile_nodes.get_all_tile_nodes():
+		var target_pos := tile_node.pos()
+		if seen.has(target_pos):
+			continue
+		if _is_premove_capture_target(piece, target_pos):
+			targets.append(target_pos)
+			seen[target_pos] = true
+	return targets
+
+func _is_premove_capture_target(piece: Piece, target_pos: Vector2i) -> bool:
+	if not b.tile_map.has_tile(target_pos):
+		return false
+	if not piece.is_attacking_square(target_pos, b):
+		return false
+	if not b.piece_map.has_piece(target_pos):
+		return true
+	var occupant := b.piece_map.get_piece(target_pos)
+	if occupant.team.is_hostile_to(piece.team):
+		return true
+	# Recapture premove: destination currently has a friendly piece (e.g. piece opponent is about to capture)
+	return occupant.team == piece.team
+
+func _can_premove_to(from_piece: PieceNode, target_pos: Vector2i) -> bool:
+	for target: Vector2i in _get_premove_targets(from_piece.piece().pos):
+		if target == target_pos:
+			return true
+	return false
+
+func _build_premove_action(from_piece: PieceNode, target_pos: Vector2i) -> MoveAction:
+	var piece := from_piece.piece()
+	var from := piece.pos
+	for move: Move in piece.get_available_moves(b):
+		if move.to != target_pos:
+			continue
+		var captured_piece_id := 0
+		if move.is_capture():
+			var captured_pos := target_pos
+			if move.is_en_passant():
+				captured_pos = Vector2i(target_pos.x, from.y)
+			if b.piece_map.has_piece(captured_pos):
+				captured_piece_id = piece_nodes.get_piece_node_by_pos(captured_pos).id()
+		return MoveAction.new(from_piece.id(), target_pos, move.info, Piece.Type.UNSET, captured_piece_id)
+	if _is_premove_capture_target(piece, target_pos):
+		var captured_piece_id := 0
+		if b.piece_map.has_piece(target_pos):
+			var occupant := b.piece_map.get_piece(target_pos)
+			if occupant.team.is_hostile_to(piece.team):
+				captured_piece_id = piece_nodes.get_piece_node_by_pos(target_pos).id()
+		return MoveAction.new(from_piece.id(), target_pos, Move.CAPTURE, Piece.Type.UNSET, captured_piece_id)
+	return null
+
+func _set_premove(from_piece: PieceNode, target_pos: Vector2i) -> void:
+	if not Settings.premoving_enabled:
+		return
+	var action := _build_premove_action(from_piece, target_pos)
+	if action == null:
+		return
+	premove_action = action
+	_show_premove_highlight(from_piece.piece().pos, target_pos)
+	_select_piece_node(null)
+
+func _show_premove_highlight(from: Vector2i, to: Vector2i) -> void:
+	tile_nodes.highlight_premove_squares([from, to])
+
+func _clear_premove() -> void:
+	premove_action = null
+	tile_nodes.clear_premove_highlight()
+
+func _is_premove_still_valid() -> bool:
+	if premove_action == null:
+		return false
+	if not piece_nodes.has_piece_node(premove_action.piece_id):
+		return false
+	var piece_node := piece_nodes.get_piece_node(premove_action.piece_id)
+	if not b.piece_map.has_piece(piece_node.piece().pos):
+		return false
+	return b.piece_map.get_piece(piece_node.piece().pos).team == player_team
+
+func _try_execute_premove() -> void:
+	if not Settings.premoving_enabled:
+		_clear_premove()
+		return
+	if not _is_premove_still_valid():
+		_clear_premove()
+		return
+	if b.team_to_move != player_team:
+		return
+	
+	var action := premove_action
+	_clear_premove()
+	
+	var piece_node := piece_nodes.get_piece_node(action.piece_id)
+	selected_piece_node = piece_node
+	var target_piece_node: PieceNode = null
+	if b.piece_map.has_piece(action.to):
+		target_piece_node = piece_nodes.get_piece_node_by_pos(action.to)
+	if not _attempt_move_to(action.to, target_piece_node):
+		GameCamera.get_instance().shake(0.1, 1.0)
+
+func _attempt_move_to(target_pos: Vector2i, target_piece_node: PieceNode = null) -> bool:
+	if not selected_piece_node:
+		return false
+	if b.team_to_move != player_team:
+		return false
+	
+	assert(selected_piece_node.piece().team == player_team)
+	
+	var castle_move := _get_castle_move_to(target_pos)
+	if castle_move != null:
+		var castle_action := MoveAction.new(selected_piece_node.id(), castle_move.to, castle_move.info)
+		perform_move_action(castle_action)
+		end_player_turn()
+		return true
+	
+	if target_piece_node and _can_capture(target_piece_node):
+		if b.tile_map.is_promotion_tile(target_piece_node.piece().pos, player_team) and selected_piece_node.piece().type == Piece.Type.PAWN:
+			temp_move_action = MoveAction.new(selected_piece_node.id(), target_piece_node.piece().pos, Move.CAPTURE, Piece.Type.UNSET, target_piece_node.id())
+			input_state = InputState.CHOOSING_PROMOTION
+			promotion_ui.show()
+			return true
+		var capture_action := MoveAction.new(selected_piece_node.id(), target_piece_node.piece().pos, Move.CAPTURE, Piece.Type.UNSET, target_piece_node.id())
+		perform_move_action(capture_action)
+		end_player_turn()
+		return true
+	
+	if not _can_move_to_pos(target_pos):
+		return false
+	
+	var target_move := _get_available_move_to(target_pos)
+	if b.tile_map.is_promotion_tile(target_pos, player_team) and selected_piece_node.piece().type == Piece.Type.PAWN:
+		temp_move_action = MoveAction.new(selected_piece_node.id(), target_pos, 0, Piece.Type.UNSET)
+		input_state = InputState.CHOOSING_PROMOTION
+		promotion_ui.show()
+		return true
+	if target_move != null and target_move.is_en_passant():
+		var captured_pos := Vector2i(target_pos.x, selected_piece_node.piece().pos.y)
+		var captured_node := piece_nodes.get_piece_node_by_pos(captured_pos)
+		if captured_node == null:
+			return false
+		var captured_piece_id := captured_node.id()
+		var en_passant_action := MoveAction.new(selected_piece_node.id(), target_pos, target_move.info, Piece.Type.UNSET, captured_piece_id)
+		perform_move_action(en_passant_action)
+		end_player_turn()
+		return true
+	
+	var move_info: int = target_move.info if target_move else 0
+	if move_info & Move.CAPTURE:
+		move_info = move_info & ~Move.CAPTURE
+	var move_action := MoveAction.new(selected_piece_node.id(), target_pos, move_info)
+	perform_move_action(move_action)
+	end_player_turn()
+	return true
+
 #endregion
+
+func _resolve_captured_piece_node(move_action: MoveAction, moving_piece_node: PieceNode) -> PieceNode:
+	if move_action.captured_piece_id != 0 and piece_nodes.has_piece_node(move_action.captured_piece_id):
+		return piece_nodes.get_piece_node(move_action.captured_piece_id)
+	if not move_action.is_capture():
+		return null
+	var captured_pos := move_action.to
+	if move_action.is_en_passant():
+		captured_pos = Vector2i(move_action.to.x, moving_piece_node.piece().pos.y)
+	if not b.piece_map.has_piece(captured_pos):
+		return null
+	return piece_nodes.get_piece_node_by_pos(captured_pos)
 
 func perform_move_action(move_action: MoveAction) -> void:
 	assert(move_action)
 	assert(state == BoardNodeState.INITIALIZED)
 	
+	if _is_dragging or _drag_piece_node:
+		_abort_drag(false)
+	
+	if not piece_nodes.has_piece_node(move_action.piece_id):
+		_clear_premove()
+		return
+	
 	var piece_node: PieceNode = piece_nodes.get_piece_node(move_action.piece_id)
 	var prev_team_to_move := b.team_to_move
+	var captured_piece_node: PieceNode = _resolve_captured_piece_node(move_action, piece_node)
 
 	# For castling, capture the rook's node and destination before the board
 	# state changes (the rook's original square becomes empty afterwards)
@@ -271,18 +623,23 @@ func perform_move_action(move_action: MoveAction) -> void:
 		castle_rook_node = piece_nodes.get_piece_node_by_pos(rook_from)
 		castle_rook_to = king_from + castle_dir
 
+	var move_info := move_action.info
+	if move_action.is_capture() and captured_piece_node == null:
+		move_info = move_info & ~Move.CAPTURE
+		move_info = move_info & ~Move.EN_PASSANT
+
 	# Update backend board state
-	b = b.perform_move(Move.new(piece_node.piece().pos, move_action.to, move_action.info, move_action.promo_info))
+	b = b.perform_move(Move.new(piece_node.piece().pos, move_action.to, move_info, move_action.promo_info))
 	
 	# Handle captures
-	if move_action.is_capture():
-		var captured_piece_node: PieceNode = piece_nodes.get_piece_node(move_action.captured_piece_id)
+	if captured_piece_node:
 		var shake_intensity := minf(2.0, captured_piece_node.piece().get_worth() * 0.15)
 		GameCamera.get_instance().shake(0.2, shake_intensity)
 		var capture_particles: Node2D = preload("res://frontend/vfx/capture_particles.tscn").instantiate()
 		add_child(capture_particles)
 		capture_particles.position = captured_piece_node.position + Vector2(0, 5)
-		piece_nodes.free_piece_node(move_action.captured_piece_id)
+		if piece_nodes.has_piece_node(captured_piece_node.id()):
+			piece_nodes.free_piece_node(captured_piece_node.id())
 	elif move_action.is_check():
 		GameCamera.get_instance().shake(0.2, 2.0)
 	
@@ -338,7 +695,11 @@ func perform_move_action(move_action: MoveAction) -> void:
 				for move: Move in available_moves:
 					tiles_to_highlight.append(move.to)
 				tile_nodes.highlight_tiles(tiles_to_highlight)
-	input_state = InputState.NONE
+	if input_state != InputState.CHOOSING_PROMOTION:
+		input_state = InputState.NONE
+	
+	if not _is_premove_still_valid():
+		_clear_premove()
 
 func start_ai_vs_ai() -> void:
 	ai_vs_ai_mode = true
@@ -362,6 +723,15 @@ func _reset_board_state() -> void:
 		input_state = InputState.NONE
 		selected_piece_node = null
 		temp_move_action = null
+		premove_action = null
+		_pointer_down = false
+		_active_pointer_id = -1
+		_is_dragging = false
+		_drag_piece_node = null
+		_press_piece_node = null
+		_pending_premove_execute = false
+		_suppress_click_signals = false
+		tile_nodes.clear_premove_highlight()
 
 func _create_board_ui() -> void:
 	# Create UI elements

--- a/frontend/board/tile_nodes.gd
+++ b/frontend/board/tile_nodes.gd
@@ -7,6 +7,9 @@ const tile_node_scene := preload("res://frontend/tile/tile_node.tscn")
 var _tile_nodes: Array[Array]
 var _cached_tile_count := 0
 var _highlighted_tiles: Array[Vector2i] = []
+var _premove_from: Vector2i = Vector2i(-1, -1)
+var _premove_to: Vector2i = Vector2i(-1, -1)
+var _drag_hover_tile: Vector2i = Vector2i(-1, -1)
 
 func get_all_tile_nodes() -> Array[TileNode]:
 	var all_tile_nodes: Array[TileNode] = []
@@ -54,10 +57,54 @@ func highlight_tiles(tiles: Array[Vector2i]) -> void:
 		get_tile_node(tile_pos).set_show_dot(true)
 	_highlighted_tiles = tiles
 
+func highlight_premove_squares(squares: Array[Vector2i]) -> void:
+	clear_premove_highlight()
+	for pos: Vector2i in squares:
+		if has_tile_node(pos):
+			get_tile_node(pos).set_show_premove(true)
+
+func highlight_premove_tiles(from: Vector2i, to: Vector2i) -> void:
+	highlight_premove_squares([from, to])
+
+func clear_premove_highlight() -> void:
+	for tile_node: TileNode in get_all_tile_nodes():
+		tile_node.set_show_premove(false)
+	_premove_from = Vector2i(-1, -1)
+	_premove_to = Vector2i(-1, -1)
+
+func set_drag_hover_tile(board_pos: Vector2i) -> void:
+	if _drag_hover_tile == board_pos:
+		return
+	if _drag_hover_tile != Vector2i(-1, -1) and has_tile_node(_drag_hover_tile):
+		get_tile_node(_drag_hover_tile).set_show_drag_hover(false)
+	_drag_hover_tile = board_pos
+	if _drag_hover_tile != Vector2i(-1, -1) and has_tile_node(_drag_hover_tile):
+		get_tile_node(_drag_hover_tile).set_show_drag_hover(true)
+
+func clear_drag_hover() -> void:
+	set_drag_hover_tile(Vector2i(-1, -1))
+
+func world_pos_to_board_pos(world_pos: Vector2) -> Vector2i:
+	var local := to_local(world_pos)
+	var grid := local / 16.0 + Vector2.ONE * Config.max_board_size * 0.5
+	return Vector2i(roundi(grid.x), roundi(grid.y))
+
+func get_tile_at_world_pos(world_pos: Vector2) -> TileNode:
+	var board_pos := world_pos_to_board_pos(world_pos)
+	if not has_tile_node(board_pos):
+		return null
+	return get_tile_node(board_pos)
+
+func is_board_pos_in_bounds(coord: Vector2i) -> bool:
+	return coord.x >= 0 and coord.y >= 0 and coord.x < Config.max_board_size and coord.y < Config.max_board_size
+
 func get_tile_node(coord: Vector2i) -> TileNode:
+	assert(is_board_pos_in_bounds(coord))
 	return _tile_nodes[coord.y][coord.x]
 
 func has_tile_node(coord: Vector2i) -> bool:
+	if not is_board_pos_in_bounds(coord):
+		return false
 	return _tile_nodes[coord.y][coord.x] != null
 
 func num_tile_nodes() -> int:

--- a/frontend/game.gd
+++ b/frontend/game.gd
@@ -4,6 +4,7 @@ class_name Game extends Node2D
 @onready var game_over_label: Label = $GameOverLayer/Rect/H/Label
 @onready var game_over_rect: Control = $GameOverLayer/Rect
 @onready var settings_rect: Control = $SettingsLayer/Rect
+@onready var premoving_checkbox: CheckButton = $SettingsLayer/Rect/H/PremovingCheckBox
 @onready var upgrade_select_ui: UpgradeSelectUI = $UpgradeSelectUI
 
 var game_setup: GameSetup
@@ -13,6 +14,7 @@ var wins_this_run: int = 0
 
 func init_with_game_setup(_game_setup: GameSetup) -> void:
 	self.game_setup = _game_setup
+	premoving_checkbox.button_pressed = Settings.premoving_enabled
 	board.init_with_game_setup(_game_setup)
 
 func init_randomly() -> void:
@@ -109,3 +111,8 @@ func _on_settings_button_pressed() -> void:
 
 func _on_back_button_pressed() -> void:
 	_close_settings()
+
+func _on_premoving_checkbox_toggled(enabled: bool) -> void:
+	Settings.save_premoving_enabled(enabled)
+	if not enabled:
+		board.clear_premoves()

--- a/frontend/game.tscn
+++ b/frontend/game.tscn
@@ -1,4 +1,4 @@
-[gd_scene load_steps=11 format=3 uid="uid://bb0qxkgwbx5xc"]
+[gd_scene format=3 uid="uid://bb0qxkgwbx5xc"]
 
 [ext_resource type="Script" uid="uid://bmw6lvpdpokau" path="res://frontend/game.gd" id="1_qfs6o"]
 [ext_resource type="PackedScene" uid="uid://b0v2ttp4dudf4" path="res://frontend/board/board_node.tscn" id="2_b7sum"]
@@ -23,13 +23,13 @@ background_color = Color(0.337754, 0.288089, 0.552513, 1)
 [sub_resource type="LabelSettings" id="LabelSettings_pfcdr"]
 font_size = 80
 
-[node name="Game" type="Node2D"]
+[node name="Game" type="Node2D" unique_id=1758435718]
 script = ExtResource("1_qfs6o")
 
-[node name="DecorLayer" type="CanvasLayer" parent="."]
+[node name="DecorLayer" type="CanvasLayer" parent="." unique_id=106059161]
 layer = -1
 
-[node name="GPUParticles2D" type="GPUParticles2D" parent="DecorLayer"]
+[node name="GPUParticles2D" type="GPUParticles2D" parent="DecorLayer" unique_id=1815685001]
 position = Vector2(-99, 202)
 amount = 14
 texture = SubResource("GradientTexture2D_pnr3g")
@@ -39,17 +39,17 @@ explosiveness = 0.11
 randomness = 0.06
 process_material = ExtResource("2_uh1ml")
 
-[node name="BoardNode" parent="." instance=ExtResource("2_b7sum")]
+[node name="BoardNode" parent="." unique_id=898326372 instance=ExtResource("2_b7sum")]
 
-[node name="GameCamera" parent="." instance=ExtResource("3_bh0d3")]
+[node name="GameCamera" parent="." unique_id=1808011394 instance=ExtResource("3_bh0d3")]
 position = Vector2(0, -9)
 
-[node name="WorldEnvironment" type="WorldEnvironment" parent="."]
+[node name="WorldEnvironment" type="WorldEnvironment" parent="." unique_id=1570730886]
 environment = SubResource("Environment_xnp5u")
 
-[node name="UILayer" type="CanvasLayer" parent="."]
+[node name="UILayer" type="CanvasLayer" parent="." unique_id=1637510617]
 
-[node name="SettingsButton" type="Button" parent="UILayer"]
+[node name="SettingsButton" type="Button" parent="UILayer" unique_id=938474639]
 anchors_preset = 3
 anchor_left = 1.0
 anchor_top = 1.0
@@ -64,9 +64,9 @@ grow_vertical = 0
 size_flags_vertical = 4
 text = "Settings"
 
-[node name="GameOverLayer" type="CanvasLayer" parent="."]
+[node name="GameOverLayer" type="CanvasLayer" parent="." unique_id=1184263621]
 
-[node name="Rect" type="NinePatchRect" parent="GameOverLayer"]
+[node name="Rect" type="NinePatchRect" parent="GameOverLayer" unique_id=827843656]
 visible = false
 self_modulate = Color(0, 0, 0, 0.647059)
 anchors_preset = 15
@@ -85,7 +85,7 @@ patch_margin_top = 24
 patch_margin_right = 24
 patch_margin_bottom = 24
 
-[node name="H" type="VBoxContainer" parent="GameOverLayer/Rect"]
+[node name="H" type="VBoxContainer" parent="GameOverLayer/Rect" unique_id=20965666]
 layout_mode = 1
 anchors_preset = 15
 anchor_right = 1.0
@@ -99,21 +99,21 @@ mouse_filter = 0
 theme_override_constants/separation = 80
 alignment = 1
 
-[node name="Label" type="Label" parent="GameOverLayer/Rect/H"]
+[node name="Label" type="Label" parent="GameOverLayer/Rect/H" unique_id=813790035]
 layout_mode = 2
 text = "You win!"
 label_settings = SubResource("LabelSettings_pfcdr")
 horizontal_alignment = 1
 
-[node name="ContinueButton" type="Button" parent="GameOverLayer/Rect/H"]
+[node name="ContinueButton" type="Button" parent="GameOverLayer/Rect/H" unique_id=1047019418]
 unique_name_in_owner = true
 layout_mode = 2
 size_flags_vertical = 4
 text = "Continue"
 
-[node name="SettingsLayer" type="CanvasLayer" parent="."]
+[node name="SettingsLayer" type="CanvasLayer" parent="." unique_id=1144448722]
 
-[node name="Rect" type="NinePatchRect" parent="SettingsLayer"]
+[node name="Rect" type="NinePatchRect" parent="SettingsLayer" unique_id=811705401]
 visible = false
 self_modulate = Color(0, 0, 0, 0.647059)
 anchors_preset = 15
@@ -132,7 +132,7 @@ patch_margin_top = 24
 patch_margin_right = 24
 patch_margin_bottom = 24
 
-[node name="H" type="VBoxContainer" parent="SettingsLayer/Rect"]
+[node name="H" type="VBoxContainer" parent="SettingsLayer/Rect" unique_id=1386442102]
 layout_mode = 1
 anchors_preset = 15
 anchor_right = 1.0
@@ -146,33 +146,40 @@ mouse_filter = 0
 theme_override_constants/separation = 20
 alignment = 1
 
-[node name="Label" type="Label" parent="SettingsLayer/Rect/H"]
+[node name="Label" type="Label" parent="SettingsLayer/Rect/H" unique_id=1568091327]
 layout_mode = 2
 text = "Settings"
 label_settings = SubResource("LabelSettings_pfcdr")
 horizontal_alignment = 1
 
-[node name="BackButton" type="Button" parent="SettingsLayer/Rect/H"]
+[node name="PremovingCheckBox" type="CheckButton" parent="SettingsLayer/Rect/H" unique_id=1728682171]
+layout_mode = 2
+button_pressed = true
+text = "Premoving"
+alignment = 1
+
+[node name="BackButton" type="Button" parent="SettingsLayer/Rect/H" unique_id=1831025985]
 layout_mode = 2
 size_flags_vertical = 4
 text = "Back to Game"
 
-[node name="ConcedeButton" type="Button" parent="SettingsLayer/Rect/H"]
+[node name="ConcedeButton" type="Button" parent="SettingsLayer/Rect/H" unique_id=354845512]
 layout_mode = 2
 size_flags_vertical = 4
 text = "Concede"
 
-[node name="QuitButton" type="Button" parent="SettingsLayer/Rect/H"]
+[node name="QuitButton" type="Button" parent="SettingsLayer/Rect/H" unique_id=1810733980]
 layout_mode = 2
 size_flags_vertical = 4
 text = "Quit"
 
-[node name="UpgradeSelectUI" parent="." instance=ExtResource("4_g2u0c")]
+[node name="UpgradeSelectUI" parent="." unique_id=1729618778 instance=ExtResource("4_g2u0c")]
 visible = false
 
 [connection signal="game_over" from="BoardNode" to="." method="_on_board_node_game_over"]
 [connection signal="pressed" from="UILayer/SettingsButton" to="." method="_on_settings_button_pressed"]
 [connection signal="pressed" from="GameOverLayer/Rect/H/ContinueButton" to="." method="_on_continue_button_pressed"]
+[connection signal="toggled" from="SettingsLayer/Rect/H/PremovingCheckBox" to="." method="_on_premoving_checkbox_toggled"]
 [connection signal="pressed" from="SettingsLayer/Rect/H/BackButton" to="." method="_on_back_button_pressed"]
 [connection signal="pressed" from="SettingsLayer/Rect/H/ConcedeButton" to="." method="_on_concede_button_pressed"]
 [connection signal="pressed" from="SettingsLayer/Rect/H/QuitButton" to="." method="_on_quit_button_pressed"]

--- a/frontend/pieces/piece_node.gd
+++ b/frontend/pieces/piece_node.gd
@@ -2,7 +2,8 @@ class_name PieceNode extends Node2D
 
 signal selected
 
-@onready var piece_sprite_2d: PieceSprite2D = $PieceSprite2D
+@onready var visual_pivot: Node2D = $VisualPivot
+@onready var piece_sprite_2d: PieceSprite2D = $VisualPivot/PieceSprite2D
 
 var _initialized := false
 var _id: int
@@ -11,6 +12,10 @@ var _piece: Piece
 var is_hovered: bool = false
 var is_selected: bool = false
 var _is_moving: bool = false
+var _is_dragging: bool = false
+var _drag_z_index: int = 0
+var _saved_scale: Vector2 = Vector2.ONE
+var _feedback_tween: Tween = null
 
 func _ready() -> void:
 	init_team_sprites()
@@ -26,7 +31,11 @@ func set_piece(new_piece: Piece) -> void:
 	_piece = new_piece
 
 func move_to(target_position: Vector2, is_promotion: bool = false) -> void:
+	if _is_dragging:
+		end_drag(false)
 	_is_moving = true
+	_stop_feedback_tween()
+	reset_visual_pivot()
 
 	if is_promotion:
 		var promotion_particles: Node2D = preload("res://frontend/vfx/promotion_particles.tscn").instantiate()
@@ -89,34 +98,83 @@ func _on_area_2d_mouse_exited() -> void:
 	if Settings.INPUT_MODE != "mouse_and_keyboard": return
 	set_hovered(false)
 
+func _stop_feedback_tween() -> void:
+	if _feedback_tween:
+		_feedback_tween.kill()
+		_feedback_tween = null
+
+func reset_visual_pivot() -> void:
+	_stop_feedback_tween()
+	visual_pivot.position = Vector2.ZERO
+	visual_pivot.rotation = 0.0
+	if not _is_dragging:
+		visual_pivot.scale = Vector2.ONE
+
 func set_hovered(new_hovered: bool) -> void:
 	is_hovered = new_hovered
-	if is_hovered and !_is_moving:
-		var tw := create_tween()
-		tw.tween_property(self, "position", Vector2(0, -1), 0.05).as_relative().set_ease(Tween.EASE_OUT).set_trans(Tween.TRANS_CIRC)
-	elif !is_hovered and !_is_moving:
-		var tw := create_tween()
-		tw.tween_property(self, "position", Vector2(0, 1), 0.05).as_relative().set_ease(Tween.EASE_OUT).set_trans(Tween.TRANS_CIRC)
+	if is_hovered and !_is_moving and !_is_dragging:
+		_stop_feedback_tween()
+		_feedback_tween = create_tween()
+		_feedback_tween.tween_property(visual_pivot, "position", Vector2(0, -1), 0.05).set_ease(Tween.EASE_OUT).set_trans(Tween.TRANS_CIRC)
+	elif !is_hovered and !_is_moving and !_is_dragging:
+		_stop_feedback_tween()
+		_feedback_tween = create_tween()
+		_feedback_tween.tween_property(visual_pivot, "position", Vector2.ZERO, 0.05).set_ease(Tween.EASE_OUT).set_trans(Tween.TRANS_CIRC)
 
 func set_selected(new_selected: bool) -> void:
 	is_selected = new_selected
-	if is_selected and !_is_moving:
-		var tw := create_tween().set_parallel().set_trans(Tween.TRANS_QUAD)
-		tw.set_ease(Tween.EASE_OUT)
-		tw.tween_property(self, "position", Vector2(0, -2), 0.05).as_relative()
-		tw.tween_property(self, "rotation", randf_range(-0.05, 0.05), 0.05)
-		tw.tween_property(self, "scale", Vector2.ONE * 1.1, 0.05)
-		tw.set_ease(Tween.EASE_IN)
-		tw.chain().tween_property(self, "position", calculate_target_position(), 0.05)
-		tw.tween_property(self, "rotation", 0.0, 0.05)
-		tw.tween_property(self, "scale", Vector2.ONE, 0.05)
+	if is_selected and !_is_moving and !_is_dragging:
+		_stop_feedback_tween()
+		_feedback_tween = create_tween().set_parallel().set_trans(Tween.TRANS_QUAD)
+		_feedback_tween.set_ease(Tween.EASE_OUT)
+		_feedback_tween.tween_property(visual_pivot, "position", Vector2(0, -2), 0.05)
+		_feedback_tween.tween_property(visual_pivot, "rotation", randf_range(-0.05, 0.05), 0.05)
+		_feedback_tween.tween_property(visual_pivot, "scale", Vector2.ONE * 1.1, 0.05)
+		_feedback_tween.set_ease(Tween.EASE_IN)
+		_feedback_tween.chain().tween_property(visual_pivot, "position", Vector2.ZERO, 0.05)
+		_feedback_tween.tween_property(visual_pivot, "rotation", 0.0, 0.05)
+		_feedback_tween.tween_property(visual_pivot, "scale", Vector2.ONE, 0.05)
 
 		var particles: OneShotParticles = load("res://frontend/vfx/select_particles.tscn").instantiate()
 		particles.position = position + Vector2(0, 6)
 		get_tree().root.add_child(particles)
+	elif !new_selected and !_is_moving and !_is_dragging:
+		reset_visual_pivot()
 
 func calculate_target_position() -> Vector2:
 	return (Vector2(_piece.pos) - Vector2.ONE * Config.max_board_size * 0.5) * 16
+
+func is_moving() -> bool:
+	return _is_moving
+
+func is_dragging() -> bool:
+	return _is_dragging
+
+func begin_drag() -> void:
+	_is_dragging = true
+	_stop_feedback_tween()
+	reset_visual_pivot()
+	_drag_z_index = z_index
+	z_index = 100
+	_saved_scale = visual_pivot.scale
+	visual_pivot.scale = Vector2.ONE * 1.15
+
+func update_drag_position(local_pos: Vector2) -> void:
+	position = local_pos
+
+func end_drag(restore: bool) -> void:
+	_is_dragging = false
+	z_index = _drag_z_index
+	visual_pivot.scale = _saved_scale
+	if restore:
+		position = calculate_target_position()
+
+func snap_to_position(world_position: Vector2) -> void:
+	if _is_dragging:
+		end_drag(false)
+	_stop_feedback_tween()
+	reset_visual_pivot()
+	position = world_position
 
 #endregion
 

--- a/frontend/pieces/piece_node.tscn
+++ b/frontend/pieces/piece_node.tscn
@@ -12,6 +12,14 @@ size = Vector2(16, 16)
 [node name="PieceNode" type="Node2D" groups=["piece_nodes"]]
 script = ExtResource("1_flxqp")
 
+[node name="VisualPivot" type="Node2D" parent="."]
+
+[node name="PieceSprite2D" type="Sprite2D" parent="VisualPivot"]
+editor_description = "This is the node that piece sprites will replace."
+position = Vector2(0, -5)
+script = ExtResource("2_2n7nr")
+metadata/_custom_type_script = "uid://fw7gwivhmbco"
+
 [node name="Area2D" type="Area2D" parent="."]
 collision_mask = 0
 
@@ -21,12 +29,6 @@ debug_color = Color(0, 0.6, 0.701961, 0.211765)
 
 [node name="Button" type="TouchScreenButton" parent="."]
 shape = SubResource("RectangleShape2D_q5l1u")
-
-[node name="PieceSprite2D" type="Sprite2D" parent="."]
-editor_description = "This is the node that piece sprites will replace."
-position = Vector2(0, -5)
-script = ExtResource("2_2n7nr")
-metadata/_custom_type_script = "uid://fw7gwivhmbco"
 
 [connection signal="mouse_entered" from="Area2D" to="." method="_on_area_2d_mouse_entered"]
 [connection signal="mouse_exited" from="Area2D" to="." method="_on_area_2d_mouse_exited"]

--- a/frontend/pieces/textures/bishop_white.tres
+++ b/frontend/pieces/textures/bishop_white.tres
@@ -1,4 +1,4 @@
-[gd_resource type="AtlasTexture" load_steps=2 format=3 uid="uid://f8pp8df8kycc"]
+[gd_resource type="AtlasTexture" format=3 uid="uid://f8pp8df8kycc"]
 
 [sub_resource type="CompressedTexture2D" id="CompressedTexture2D_nxsl0"]
 load_path = "res://.godot/imported/pieces_sprite_sheet.png-b320056e40fecbe295f2b805f7ade72e.ctex"

--- a/frontend/pieces/textures/knight_white.tres
+++ b/frontend/pieces/textures/knight_white.tres
@@ -1,4 +1,4 @@
-[gd_resource type="AtlasTexture" load_steps=2 format=3 uid="uid://xspvbonlidrc"]
+[gd_resource type="AtlasTexture" format=3 uid="uid://xspvbonlidrc"]
 
 [sub_resource type="CompressedTexture2D" id="CompressedTexture2D_emr1f"]
 load_path = "res://.godot/imported/pieces_sprite_sheet.png-b320056e40fecbe295f2b805f7ade72e.ctex"

--- a/frontend/pieces/textures/queen_white.tres
+++ b/frontend/pieces/textures/queen_white.tres
@@ -1,4 +1,4 @@
-[gd_resource type="AtlasTexture" load_steps=2 format=3 uid="uid://beevllaubek5f"]
+[gd_resource type="AtlasTexture" format=3 uid="uid://beevllaubek5f"]
 
 [sub_resource type="CompressedTexture2D" id="CompressedTexture2D_dgmj2"]
 load_path = "res://.godot/imported/pieces_sprite_sheet.png-b320056e40fecbe295f2b805f7ade72e.ctex"

--- a/frontend/pieces/textures/rook_white.tres
+++ b/frontend/pieces/textures/rook_white.tres
@@ -1,4 +1,4 @@
-[gd_resource type="AtlasTexture" load_steps=2 format=3 uid="uid://iehu274lcwh5"]
+[gd_resource type="AtlasTexture" format=3 uid="uid://iehu274lcwh5"]
 
 [sub_resource type="CompressedTexture2D" id="CompressedTexture2D_kevv2"]
 load_path = "res://.godot/imported/pieces_sprite_sheet.png-b320056e40fecbe295f2b805f7ade72e.ctex"

--- a/frontend/settings/settings.gd
+++ b/frontend/settings/settings.gd
@@ -1,4 +1,21 @@
 class_name Settings
 
+const SETTINGS_PATH := "user://settings.cfg"
+
 # "mouse_and_keyboard" or "touch"
 const INPUT_MODE: String = "touch"
+
+static var premoving_enabled: bool = true
+
+static func load_user_settings() -> void:
+	var config := ConfigFile.new()
+	if config.load(SETTINGS_PATH) != OK:
+		return
+	premoving_enabled = config.get_value("settings", "premoving_enabled", true)
+
+static func save_premoving_enabled(enabled: bool) -> void:
+	premoving_enabled = enabled
+	var config := ConfigFile.new()
+	config.load(SETTINGS_PATH)
+	config.set_value("settings", "premoving_enabled", enabled)
+	config.save(SETTINGS_PATH)

--- a/frontend/theme.tres
+++ b/frontend/theme.tres
@@ -14,7 +14,16 @@ texture_margin_right = 20.0
 texture_margin_bottom = 20.0
 modulate_color = Color(0.462291, 0.462291, 0.462291, 0.784314)
 
-[sub_resource type="StyleBoxEmpty" id="StyleBoxEmpty_rd8sf"]
+[sub_resource type="CompressedTexture2D" id="CompressedTexture2D_urbn3"]
+load_path = "res://.godot/imported/panel-transparent-center-009.png-111575f8205292ff7cbdcc25ad2fb6b6.ctex"
+
+[sub_resource type="StyleBoxTexture" id="StyleBoxTexture_ftthr"]
+texture = SubResource("CompressedTexture2D_urbn3")
+texture_margin_left = 20.0
+texture_margin_top = 20.0
+texture_margin_right = 20.0
+texture_margin_bottom = 20.0
+modulate_color = Color(0.860369, 0.860369, 0.860369, 1)
 
 [sub_resource type="CompressedTexture2D" id="CompressedTexture2D_femyt"]
 load_path = "res://.godot/imported/panel-transparent-center-009.png-111575f8205292ff7cbdcc25ad2fb6b6.ctex"
@@ -43,6 +52,28 @@ texture_margin_right = 20.0
 texture_margin_bottom = 20.0
 modulate_color = Color(0.899258, 0.899258, 0.899258, 1)
 
+[sub_resource type="CompressedTexture2D" id="CompressedTexture2D_hcw1s"]
+load_path = "res://.godot/imported/panel-transparent-center-009.png-111575f8205292ff7cbdcc25ad2fb6b6.ctex"
+
+[sub_resource type="StyleBoxTexture" id="StyleBoxTexture_vq2v7"]
+texture = SubResource("CompressedTexture2D_hcw1s")
+texture_margin_left = 20.0
+texture_margin_top = 20.0
+texture_margin_right = 20.0
+texture_margin_bottom = 20.0
+modulate_color = Color(0.860369, 0.860369, 0.860369, 1)
+
+[sub_resource type="CompressedTexture2D" id="CompressedTexture2D_xgvba"]
+load_path = "res://.godot/imported/panel-transparent-center-009.png-111575f8205292ff7cbdcc25ad2fb6b6.ctex"
+
+[sub_resource type="StyleBoxTexture" id="StyleBoxTexture_b8mxr"]
+texture = SubResource("CompressedTexture2D_xgvba")
+texture_margin_left = 20.0
+texture_margin_top = 20.0
+texture_margin_right = 20.0
+texture_margin_bottom = 20.0
+modulate_color = Color(0.860369, 0.860369, 0.860369, 1)
+
 [sub_resource type="StyleBoxTexture" id="StyleBoxTexture_urbn3"]
 texture = ExtResource("2_urbn3")
 texture_margin_left = 25.0
@@ -53,9 +84,11 @@ texture_margin_bottom = 25.0
 [resource]
 Button/font_sizes/font_size = 36
 Button/styles/disabled = SubResource("StyleBoxTexture_3f1aj")
-Button/styles/focus = SubResource("StyleBoxEmpty_rd8sf")
+Button/styles/focus = SubResource("StyleBoxTexture_ftthr")
 Button/styles/hover = SubResource("StyleBoxTexture_t0h1v")
 Button/styles/normal = SubResource("StyleBoxTexture_27tw2")
 Button/styles/pressed = SubResource("StyleBoxTexture_dxptr")
+CheckButton/styles/hover = SubResource("StyleBoxTexture_vq2v7")
+CheckButton/styles/hover_pressed = SubResource("StyleBoxTexture_b8mxr")
 Label/font_sizes/font_size = 36
 PanelContainer/styles/panel = SubResource("StyleBoxTexture_urbn3")

--- a/frontend/tile/tile_node.gd
+++ b/frontend/tile/tile_node.gd
@@ -3,6 +3,9 @@ class_name TileNode extends Node2D
 signal selected
 
 var _pos: Vector2i
+var _base_square_color: Color
+var _is_drag_hovered: bool = false
+var _is_premove_highlighted: bool = false
 var is_hovered: bool = false
 var is_pressed: bool = false
 var is_selected: bool = false
@@ -15,9 +18,10 @@ var is_selected: bool = false
 func init(new_pos: Vector2i) -> void:
 	_pos = new_pos
 	if (_pos.x + _pos.y) % 2 == 0:
-		square.color = Color("c7c5c3")
+		_base_square_color = Color("c7c5c3")
 	else:
-		square.color = Color("2f3350")
+		_base_square_color = Color("2f3350")
+	square.color = _base_square_color
 	name = "Tile_%v" % _pos
 	$Label.text = "%s,%s" % [_pos.x, _pos.y]
 	position = (Vector2(_pos) - Vector2.ONE * Config.max_board_size * 0.5) * 16
@@ -65,3 +69,19 @@ func set_selected(new_selected: bool) -> void:
 
 func set_show_dot(new_val: bool) -> void:
 	dot.visible = new_val
+
+func set_show_premove(new_val: bool) -> void:
+	_is_premove_highlighted = new_val
+	_apply_square_color()
+
+func set_show_drag_hover(new_val: bool) -> void:
+	_is_drag_hovered = new_val
+	_apply_square_color()
+
+func _apply_square_color() -> void:
+	if _is_drag_hovered:
+		square.color = _base_square_color.lerp(Color(0.9, 0.85, 0.4), 0.45)
+	elif _is_premove_highlighted:
+		square.color = _base_square_color.lerp(Color(0.4, 0.6, 0.9), 0.35)
+	else:
+		square.color = _base_square_color

--- a/frontend/vfx/bg_dust_particle_process_material.tres
+++ b/frontend/vfx/bg_dust_particle_process_material.tres
@@ -1,4 +1,4 @@
-[gd_resource type="ParticleProcessMaterial" load_steps=5 format=3 uid="uid://0t2e58d2d0c"]
+[gd_resource type="ParticleProcessMaterial" format=3 uid="uid://0t2e58d2d0c"]
 
 [sub_resource type="Curve" id="Curve_vjqtv"]
 _data = [Vector2(0.0101215, 1), 0.0, 0.0, 0, 0, Vector2(0.84413, 0.827782), -0.1389, -0.1389, 0, 0, Vector2(1, 0.109387), -3.1397, 0.0, 0, 0]

--- a/main.gd
+++ b/main.gd
@@ -6,6 +6,7 @@ func _ready() -> void:
 	var version: String = ProjectSettings.get_setting("application/config/version")
 	version_label.text = "v%s" % version
 	Config.load_config()
+	Settings.load_user_settings()
 	PieceRules.load_pieces()
 	Upgrades.load_upgrades()
 


### PR DESCRIPTION
Support mouse and touch drag with VisualPivot feedback, Lichess-style single premoves with tile highlights, a persisted settings toggle, and theme updates for the checkbox. Hide opponent-turn move dots when premoving is disabled.

<img width="926" height="672" alt="image" src="https://github.com/user-attachments/assets/9c9b6f1b-536d-44ab-8cdb-671130918e13" />
